### PR TITLE
papirus-suite: fix makefile in icons directories

### DIFF
--- a/gtk-icons/Makefile
+++ b/gtk-icons/Makefile
@@ -7,6 +7,8 @@ install: local
 clear:
 	-rm -rf $(INSTALLDIR)Papirus*
 local:
-	find Papirus* -type f -exec install -Dm644 '{}' "$(INSTALLDIR)/{}" \;
+	install -d $(INSTALLDIR)
+	cp -rf Papirus-Dark-GTK $(INSTALLDIR)
+	cp -rf Papirus-GTK $(INSTALLDIR)
 
 uninstall: clear

--- a/kde-pack/icons/Makefile
+++ b/kde-pack/icons/Makefile
@@ -18,10 +18,7 @@ local:
 	install -d $(AMAROKDIR)/papirus-black-panel/
 	install -d $(AMAROKDIR)/papirus-dark/
 	
-	find papirus -type f -exec install -Dm644 '{}' "$(INSTALLDIR)/{}" \;
-	find papirus-black-panel -type f -exec install -Dm644 '{}' "$(INSTALLDIR)/{}" \;
-	find papirus-dark -type f -exec install -Dm644 '{}' "$(INSTALLDIR)/{}" \;
-
+	cp -rf papirus* $(INSTALLDIR)
 	cp -rf papirus/extra-icons/amarok/*              $(AMAROKDIR)/papirus/
 	cp -rf papirus-black-panel/extra-icons/amarok/*  $(AMAROKDIR)/papirus-black-panel/
 	cp -rf papirus-dark/extra-icons/amarok/*         $(AMAROKDIR)/papirus-dark/


### PR DESCRIPTION
@varlesh  I forgot about `find` tool feature... it skip symlinks. This pull revert using `find` tool in icon install. Sorry for mess up...
